### PR TITLE
Fix code scanning alert no. 5: Uncontrolled command line

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "python-shell": "^5.0.0",
     "simple-git": "^3.27.0",
     "socket.io": "^4.8.1",
-    "xmldom": "^0.6.0"
+    "xmldom": "^0.6.0",
+    "shell-quote": "^1.8.1"
   },
   "description": "ScriptBlocks IDE",
   "author": "ScriptBlocks Team"

--- a/server.js
+++ b/server.js
@@ -3,7 +3,8 @@ const http = require('http');
 const path = require('path');
 const fs = require('fs');
 const simpleGit = require('simple-git');
-const { exec } = require('child_process');
+const { execFile } = require('child_process');
+const shellQuote = require('shell-quote');
 
 const app = express();
 const server = http.createServer(app);
@@ -68,7 +69,11 @@ const startServer = async () => {
     app.post('/execute-command', (req, res) => {
         const { command } = req.body;
 
-        exec(command, (error, stdout, stderr) => {
+        const parsedCommand = shellQuote.parse(command);
+        const cmd = parsedCommand[0];
+        const args = parsedCommand.slice(1);
+
+        execFile(cmd, args, (error, stdout, stderr) => {
             if (error) {
                 console.error(`Error executing command: ${error}`);
                 return res.json({ success: false, output: stderr || error.message });


### PR DESCRIPTION
Fixes [https://github.com/ScriptBlocks/ScriptBlocks/security/code-scanning/5](https://github.com/ScriptBlocks/ScriptBlocks/security/code-scanning/5)

To fix the problem, we should avoid using `exec` with user-provided input directly. Instead, we can use `execFile` or `execFileSync`, which do not spawn a shell and accept command arguments as an array of strings. This approach is safer and helps prevent command injection vulnerabilities.

In this specific case, we will:
1. Replace `exec` with `execFile`.
2. Parse the user-provided command string into an array of arguments using a library like `shell-quote` to ensure safe handling of the input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
